### PR TITLE
fix: zone startup crash + feat: static API token auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,12 @@ The application expects all configuration to be passed in via environment variab
 | `LISTEN_PORT`         | The port the webhook server listens ono (defaults to `3000`).                                             |
 | `TECHNITIUM_URL`      | The URL of the Technitium DNS server (required).                                                          |
 | `TECHNITIUM_USERNAME` | The username to authenticate with the Technitium DNS server (required).                                   |
-| `TECHNITIUM_PASSWORD` | The password to authenticate with the Technitium DNS server (required).                                   |
+| `TECHNITIUM_PASSWORD` | The password for the user. Required when `TECHNITIUM_TOKEN` is not supplied.                              |
+| `TECHNITIUM_TOKEN`    | A pre-generated Technitium API token. When set, the webhook skips password login and reuses this token.   |
 | `ZONE`                | The zone to manage (e.g. `example.com`, required).                                                        |
 | `DOMAIN_FILTERS`      | A semicolon-separated list of domain filters to apply (e.g. `foo.example.com;bar.example.com`, optional). |
+
+Provide either `TECHNITIUM_PASSWORD` *or* `TECHNITIUM_TOKEN`. When a token is supplied, the webhook uses it directly and does not attempt to refresh credentials via the login endpoint.
 
 ### Zone Handling
 
@@ -90,7 +93,9 @@ type: Opaque
 apiVersion: v1
 stringData:
   TECHNITIUM_USERNAME: admin
-  TECHNITIUM_PASSWORD: admin
+  # Provide exactly one of the following:
+  TECHNITIUM_PASSWORD: example-password
+  # TECHNITIUM_TOKEN: example-static-token
 metadata:
   name: technitium-dns
   namespace: external-dns

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,6 +10,7 @@ pub struct AppState {
     pub config: Config,
     pub is_ready: RwLock<bool>,
     pub client: RwLock<technitium::TechnitiumClient>,
+    pub use_static_token: bool,
 }
 
 impl AppState {

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,8 @@ pub struct Config {
     pub listen_port: String,
     pub technitium_url: String,
     pub technitium_username: String,
-    pub technitium_password: String,
+    pub technitium_password: Option<String>,
+    pub technitium_token: Option<String>,
     pub zone: String,
     pub domain_filters: Option<Vec<String>>,
 }
@@ -18,7 +19,8 @@ impl Default for Config {
             listen_port: "3000".to_string(),
             technitium_url: String::new(),
             technitium_username: String::new(),
-            technitium_password: String::new(),
+            technitium_password: None,
+            technitium_token: None,
             zone: String::new(),
             domain_filters: None,
         }
@@ -27,14 +29,27 @@ impl Default for Config {
 
 impl Config {
     pub fn from_env() -> Self {
+        let technitium_password = env::var("TECHNITIUM_PASSWORD")
+            .ok()
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty());
+        let technitium_token = env::var("TECHNITIUM_TOKEN")
+            .ok()
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty());
+
+        if technitium_password.is_none() && technitium_token.is_none() {
+            panic!("Configure TECHNITIUM_PASSWORD or TECHNITIUM_TOKEN");
+        }
+
         Self {
             listen_address: env::var("LISTEN_ADDRESS").unwrap_or_else(|_| "0.0.0.0".to_string()),
             listen_port: env::var("LISTEN_PORT").unwrap_or_else(|_| "3000".to_string()),
             technitium_url: env::var("TECHNITIUM_URL").expect("Missing TECHNITIUM_URL"),
             technitium_username: env::var("TECHNITIUM_USERNAME")
                 .expect("Missing TECHNITIUM_USERNAME"),
-            technitium_password: env::var("TECHNITIUM_PASSWORD")
-                .expect("Missing TECHNITIUM_PASSWORD"),
+            technitium_password,
+            technitium_token,
             zone: env::var("ZONE").expect("Missing ZONE"),
             domain_filters: env::var("DOMAIN_FILTERS")
                 .ok()

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ async fn check_zone_existence(
     loop {
         let zones = client
             .list_zones(technitium::ListZonesPayload {
-                zone: app_state.config.zone.clone(),
+                zone: None,
                 page_number: Some(page_number),
                 zones_per_page: Some(100),
             })
@@ -71,6 +71,32 @@ async fn create_default_zone(app_state: &Arc<AppState>) -> Result<(), technitium
     Ok(())
 }
 
+async fn ensure_zone_ready(app_state: &Arc<AppState>) -> Result<(), technitium::TechnitiumError> {
+    debug!("Verifying and preparing the DNS Zone...");
+
+    if check_zone_existence(app_state).await? {
+        info!(
+            "Zone {} exists in Technitium DNS server.",
+            &app_state.config.zone
+        );
+        return Ok(());
+    }
+
+    match create_default_zone(app_state).await {
+        Ok(()) => Ok(()),
+        Err(technitium::TechnitiumError::ApiError(msg))
+            if msg.to_lowercase().contains("zone already exists") =>
+        {
+            info!(
+                "Zone {} already exists in Technitium DNS server, continuing.",
+                &app_state.config.zone
+            );
+            Ok(())
+        }
+        Err(err) => Err(err),
+    }
+}
+
 async fn setup_technitium_connection(app_state: Arc<AppState>) {
     // Construct the login payload using the credentials from the configuration
     let login_payload = technitium::LoginPayload {
@@ -95,29 +121,12 @@ async fn setup_technitium_connection(app_state: Arc<AppState>) {
     );
     tokio::spawn(auto_renew_technitium_token(Arc::clone(&app_state)));
 
-    debug!("Verifying and preparing the DNS Zone...");
-
-    let zone_exists = match check_zone_existence(&app_state).await {
-        Ok(ret) => ret,
-        Err(e) => {
-            error!("Failed to list zones: {}", e);
-            std::process::exit(1);
-        }
-    };
-
-    if zone_exists {
-        info!(
-            "Zone {} exists in Technitium DNS server.",
-            &app_state.config.zone
+    if let Err(e) = ensure_zone_ready(&app_state).await {
+        error!(
+            "Failed to prepare the zone {} in Technitium DNS server: {}",
+            &app_state.config.zone, e
         );
-    } else {
-        if let Err(e) = create_default_zone(&app_state).await {
-            error!(
-                "Failed to create the zone {} in Technitium DNS server: {}",
-                &app_state.config.zone, e
-            );
-            std::process::exit(1);
-        }
+        std::process::exit(1);
     }
 
     *app_state.is_ready.write().await = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,28 +98,54 @@ async fn ensure_zone_ready(app_state: &Arc<AppState>) -> Result<(), technitium::
 }
 
 async fn setup_technitium_connection(app_state: Arc<AppState>) {
-    // Construct the login payload using the credentials from the configuration
-    let login_payload = technitium::LoginPayload {
-        username: app_state.config.technitium_username.clone(),
-        password: app_state.config.technitium_password.clone(),
-    };
-
-    // Attempt to log in to Technitium using the login payload
-    let token = match app_state.client.read().await.login(login_payload).await {
-        Ok(resp) => resp.token,
-        Err(e) => {
-            error!("Failed to log in to Technitium DNS server: {}", e);
+    if app_state.use_static_token {
+        if let Some(token) = &app_state.config.technitium_token {
+            info!("Using static Technitium API token from configuration.");
+            *app_state.client.write().await = technitium::TechnitiumClient::new(
+                app_state.config.technitium_url.clone(),
+                token.clone(),
+                HTTP_TIMEOUT,
+            );
+        } else {
+            error!("TECHNITIUM_TOKEN must be configured when TECHNITIUM_PASSWORD is not set");
             std::process::exit(1);
         }
-    };
+    } else {
+        let password = match &app_state.config.technitium_password {
+            Some(password) => password.clone(),
+            None => {
+                error!("TECHNITIUM_PASSWORD must be configured when TECHNITIUM_TOKEN is not set");
+                std::process::exit(1);
+            }
+        };
 
-    info!("Successfully logged into Technitium DNS server with received token.");
-    *app_state.client.write().await = technitium::TechnitiumClient::new(
-        app_state.config.technitium_url.clone(),
-        token,
-        HTTP_TIMEOUT,
-    );
-    tokio::spawn(auto_renew_technitium_token(Arc::clone(&app_state)));
+        let login_payload = technitium::LoginPayload {
+            username: app_state.config.technitium_username.clone(),
+            password: password.clone(),
+        };
+
+        let token = match app_state.client.read().await.login(login_payload).await {
+            Ok(resp) => resp.token,
+            Err(e) => {
+                error!("Failed to log in to Technitium DNS server: {}", e);
+                std::process::exit(1);
+            }
+        };
+
+        info!("Successfully logged into Technitium DNS server with received token.");
+        *app_state.client.write().await = technitium::TechnitiumClient::new(
+            app_state.config.technitium_url.clone(),
+            token,
+            HTTP_TIMEOUT,
+        );
+
+        let username = app_state.config.technitium_username.clone();
+        tokio::spawn(auto_renew_technitium_token(
+            Arc::clone(&app_state),
+            username,
+            password,
+        ));
+    }
 
     if let Err(e) = ensure_zone_ready(&app_state).await {
         error!(
@@ -132,7 +158,11 @@ async fn setup_technitium_connection(app_state: Arc<AppState>) {
     *app_state.is_ready.write().await = true;
 }
 
-async fn auto_renew_technitium_token(app_state: Arc<AppState>) {
+async fn auto_renew_technitium_token(
+    app_state: Arc<AppState>,
+    username: String,
+    password: String,
+) {
     const DURATION_SUCCESS: Duration = Duration::from_secs(20 * 60);
     const DURATION_FAILURE: Duration = Duration::from_secs(60);
 
@@ -140,13 +170,11 @@ async fn auto_renew_technitium_token(app_state: Arc<AppState>) {
     loop {
         sleep(sleep_for).await;
 
-        // Construct the login payload using the credentials from the configuration
         let login_payload = technitium::LoginPayload {
-            username: app_state.config.technitium_username.clone(),
-            password: app_state.config.technitium_password.clone(),
+            username: username.clone(),
+            password: password.clone(),
         };
 
-        // Attempt to log in to Technitium using the login payload
         let token = match app_state.client.read().await.login(login_payload).await {
             Ok(resp) => resp.token,
             Err(e) => {
@@ -179,15 +207,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .init();
 
     let config = Config::from_env();
+    let initial_token = config.technitium_token.clone().unwrap_or_default();
     let client = technitium::TechnitiumClient::new(
         config.technitium_url.clone(),
-        Default::default(), // no token initially
+        initial_token,
         HTTP_TIMEOUT,
     );
+    let use_static_token = config.technitium_password.is_none();
     let app_state = Arc::new(AppState {
         config,
         is_ready: RwLock::new(false),
         client: RwLock::new(client),
+        use_static_token,
     });
 
     // Check and create zone if necessary

--- a/src/technitium/models.rs
+++ b/src/technitium/models.rs
@@ -36,7 +36,8 @@ pub struct CreateZoneResponse {
 
 #[derive(Debug, Serialize, Default)]
 pub struct ListZonesPayload {
-    pub zone: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub zone: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "pageNumber")]
     pub page_number: Option<u32>,
@@ -292,74 +293,6 @@ pub struct RecordCNAMEData {
 pub struct RecordTXTData {
     #[serde(rename = "text")]
     pub text: String,
-}
-
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
-pub struct RecordAUpdate {
-    #[serde(flatten)]
-    pub current: RecordAData,
-    #[serde(rename = "newIpAddress")]
-    pub ip_address: String,
-}
-
-impl From<RecordAData> for RecordAUpdate {
-    fn from(data: RecordAData) -> Self {
-        Self {
-            current: data.clone(),
-            ip_address: data.ip_address,
-        }
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
-pub struct RecordAAAAUpdate {
-    #[serde(flatten)]
-    pub current: RecordAAAAData,
-    #[serde(rename = "newIpAddress")]
-    pub ip_address: String,
-}
-
-impl From<RecordAAAAData> for RecordAAAAUpdate {
-    fn from(data: RecordAAAAData) -> Self {
-        Self {
-            current: data.clone(),
-            ip_address: data.ip_address,
-        }
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
-pub struct RecordCNAMEUpdate {
-    #[serde(flatten)]
-    pub current: RecordCNAMEData,
-    #[serde(rename = "newCname")]
-    pub cname: String,
-}
-
-impl From<RecordCNAMEData> for RecordCNAMEUpdate {
-    fn from(data: RecordCNAMEData) -> Self {
-        Self {
-            current: data.clone(),
-            cname: data.cname,
-        }
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
-pub struct RecordTXTUpdate {
-    #[serde(flatten)]
-    pub current: RecordTXTData,
-    #[serde(rename = "newText")]
-    pub text: String,
-}
-
-impl From<RecordTXTData> for RecordTXTUpdate {
-    fn from(data: RecordTXTData) -> Self {
-        Self {
-            current: data.clone(),
-            text: data.text,
-        }
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Default, Eq, PartialEq)]


### PR DESCRIPTION
## Summary

- **Fix zone listing and startup crash when zone already exists** — `ListZonesPayload.zone` is now `Option<String>` (the API returns all zones when the field is omitted, fixing incorrect filtering). Startup now gracefully handles "zone already exists" errors instead of crashing. Removed dead record-update structs.
- **Support static API token authentication via `TECHNITIUM_TOKEN`** — Adds an alternative to username/password login. When `TECHNITIUM_TOKEN` is set, the webhook uses it directly and skips the login call and the background token-renewal task. This is useful for environments where a long-lived API token is preferred.

## Changes

### Commit 1: `fix: zone listing and startup crash on zone already existing`
- `src/technitium/models.rs`: `ListZonesPayload.zone` changed from `String` to `Option<String>` with `skip_serializing_if`
- `src/main.rs`: `check_zone_existence` now passes `zone: None` to list all zones; extracted `ensure_zone_ready()` that swallows "zone already exists" API errors
- Removed unused structs: `RecordAUpdate`, `RecordAAAAUpdate`, `RecordCNAMEUpdate`, `RecordTXTUpdate`

### Commit 2: `feat: support static API token authentication via TECHNITIUM_TOKEN`
- `src/config.rs`: `technitium_password` is now `Option<String>`; added `technitium_token: Option<String>`; panics at startup if neither is provided
- `src/app.rs`: Added `use_static_token: bool` to `AppState`
- `src/main.rs`: `setup_technitium_connection` branches on static token vs password auth; token renewal task only spawned for password auth
- `README.md`: Documents the new `TECHNITIUM_TOKEN` env var and updates the Kubernetes Secret example